### PR TITLE
Mask options

### DIFF
--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -26,10 +26,10 @@ internal class Program
         var img = PixelsorterClassLib.Core.Image.LoadImage(inputImagePath);
 
 
-        Mask masker = new LuminanceMask();
+        var masker = new LuminanceMask();
 
 
-        (var o, var i) = masker.GetMask(inputImagePath, 30);
+        (var o, var i) = masker.GetMask(inputImagePath, new LuminanceMaskOptions(0.3f));
 
         var foo = Sorter.SortImage(img, SortBy.Warmth(), SortDirections.RowLeftToRight, o);
 

--- a/PixelsorterClassLib/Masks/BackgroundMask.cs
+++ b/PixelsorterClassLib/Masks/BackgroundMask.cs
@@ -12,8 +12,8 @@ namespace PixelsorterClassLib.Masks
     /// <summary>
     /// Represents options for configuring a background mask with a specified fade width.
     /// </summary>
-    /// <param name="fadeWidth">The width, in pixels, over which the background mask fades. Must be a non-negative integer.</param>
-    public record BackgroundMaskOptions(int fadeWidth) : MaskOptions;
+    /// <param name="FadeWidth">The width, in pixels, over which the background mask fades. Must be a non-negative integer.</param>
+    public record BackgroundMaskOptions(int FadeWidth) : MaskOptions;
 
     /// <summary>
     /// Provides functionality to generate a mask from an input image using a pre-trained model.
@@ -385,7 +385,7 @@ namespace PixelsorterClassLib.Masks
         {
             using var inputImage = LoadImage(inputImagePath);
             LoadModel();
-            (var mask, var invertedMask) = CreateMask(inputImage, options.fadeWidth);
+            (var mask, var invertedMask) = CreateMask(inputImage, options.FadeWidth);
             return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
         }
 
@@ -405,7 +405,7 @@ namespace PixelsorterClassLib.Masks
                 cancellationToken.ThrowIfCancellationRequested();
                 LoadModel();
                 cancellationToken.ThrowIfCancellationRequested();
-                (var mask, var invertedMask) = CreateMask(inputImage, options.fadeWidth);
+                (var mask, var invertedMask) = CreateMask(inputImage, options.FadeWidth);
                 return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
             }, cancellationToken);
         }

--- a/PixelsorterClassLib/Masks/BackgroundMask.cs
+++ b/PixelsorterClassLib/Masks/BackgroundMask.cs
@@ -393,7 +393,7 @@ namespace PixelsorterClassLib.Masks
         /// </summary>
         /// <param name="inputImagePath">The file path of the input image from which the mask will be generated. This must reference a valid image
         /// file.</param>
-        /// <param name="options">The options controlling mask generation, including the fade width applied to mask edges.</param>
+        /// <param name="options" cref="BackgroundMaskOptions" >The options controlling mask generation</param>
         /// <returns>A tuple containing the generated mask and inverted mask as NDArrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the input image cannot be loaded from the specified path.</exception>
         public override (NDArray mask, NDArray invertedMask) GetMask(String inputImagePath, BackgroundMaskOptions options)
@@ -409,7 +409,7 @@ namespace PixelsorterClassLib.Masks
         /// Asynchronously generates a mask image from the specified input image and returns it as an NDArray.
         /// </summary>
         /// <param name="inputImagePath">Path to the image file to process.</param>
-        /// <param name="options">The options controlling mask generation, including the fade width applied to mask edges.</param>
+        /// <param name="options" cref="BackgroundMaskOptions" >The options controlling mask generation</param>
         /// <param name="cancellationToken">Token to cancel the work.</param>
         /// <returns>A task returning a tuple containing the generated mask and inverted mask as NDArrays.</returns>
         public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string inputImagePath, BackgroundMaskOptions options, CancellationToken cancellationToken = default)

--- a/PixelsorterClassLib/Masks/BackgroundMask.cs
+++ b/PixelsorterClassLib/Masks/BackgroundMask.cs
@@ -1,4 +1,4 @@
-﻿using HuggingfaceHub;
+using HuggingfaceHub;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using NumSharp;
@@ -9,6 +9,10 @@ using SixLabors.ImageSharp.Processing;
 namespace PixelsorterClassLib.Masks
 {
 
+    /// <summary>
+    /// Represents options for configuring a background mask with a specified fade width.
+    /// </summary>
+    /// <param name="fadeWidth">The width, in pixels, over which the background mask fades. Must be a non-negative integer.</param>
     public record BackgroundMaskOptions(int fadeWidth) : MaskOptions;
 
     /// <summary>
@@ -372,13 +376,10 @@ namespace PixelsorterClassLib.Masks
         /// <summary>
         /// Generates a mask image from the specified input image and returns it as an NDArray.
         /// </summary>
-        /// <remarks>The method creates a temporary mask image file named 'mask.png', which is deleted
-        /// after the mask is loaded and returned.</remarks>
         /// <param name="inputImagePath">The file path of the input image from which the mask will be generated. This must reference a valid image
         /// file.</param>
-        /// <param name="fadeWidth">The width, in pixels, of the fade effect applied to the mask. Must be a non-negative integer. The default
-        /// value is 30.</param>
-        /// <returns>An NDArray containing the generated mask image.</returns>
+        /// <param name="options">The options controlling mask generation, including the fade width applied to mask edges.</param>
+        /// <returns>A tuple containing the generated mask and inverted mask as NDArrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the input image cannot be loaded from the specified path.</exception>
         public override (NDArray mask, NDArray invertedMask) GetMask(String inputImagePath, BackgroundMaskOptions options)
         {
@@ -392,9 +393,9 @@ namespace PixelsorterClassLib.Masks
         /// Asynchronously generates a mask image from the specified input image and returns it as an NDArray.
         /// </summary>
         /// <param name="inputImagePath">Path to the image file to process.</param>
-        /// <param name="fadeWidth">Fade width in pixels applied to the mask edges.</param>
+        /// <param name="options">The options controlling mask generation, including the fade width applied to mask edges.</param>
         /// <param name="cancellationToken">Token to cancel the work.</param>
-        /// <returns>A task returning the generated mask as an NDArray.</returns>
+        /// <returns>A task returning a tuple containing the generated mask and inverted mask as NDArrays.</returns>
         public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string inputImagePath, BackgroundMaskOptions options, CancellationToken cancellationToken = default)
         {
             return Task.Run(() =>

--- a/PixelsorterClassLib/Masks/BackgroundMask.cs
+++ b/PixelsorterClassLib/Masks/BackgroundMask.cs
@@ -9,6 +9,8 @@ using SixLabors.ImageSharp.Processing;
 namespace PixelsorterClassLib.Masks
 {
 
+    public record BackgroundMaskOptions(int fadeWidth) : MaskOptions;
+
     /// <summary>
     /// Provides functionality to generate a mask from an input image using a pre-trained model.
     /// </summary>
@@ -16,7 +18,7 @@ namespace PixelsorterClassLib.Masks
     /// masks. It requires an input image path and can apply a fade effect to the edges of the generated mask. The model
     /// input size is fixed at 1024x1024 pixels, and the class handles image normalization and tensor extraction for
     /// model inference.</remarks>
-    public class BackgroundMask : Mask
+    public class BackgroundMask : Mask<BackgroundMaskOptions>
     {
         private static InferenceSession? _session;
         private static string? _inputName;
@@ -378,11 +380,11 @@ namespace PixelsorterClassLib.Masks
         /// value is 30.</param>
         /// <returns>An NDArray containing the generated mask image.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the input image cannot be loaded from the specified path.</exception>
-        public override (NDArray mask, NDArray invertedMask) GetMask(String inputImagePath, int fadeWidth = 30)
+        public override (NDArray mask, NDArray invertedMask) GetMask(String inputImagePath, BackgroundMaskOptions options)
         {
             using var inputImage = LoadImage(inputImagePath);
             LoadModel();
-            (var mask, var invertedMask) = CreateMask(inputImage, fadeWidth);
+            (var mask, var invertedMask) = CreateMask(inputImage, options.fadeWidth);
             return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
         }
 
@@ -393,7 +395,7 @@ namespace PixelsorterClassLib.Masks
         /// <param name="fadeWidth">Fade width in pixels applied to the mask edges.</param>
         /// <param name="cancellationToken">Token to cancel the work.</param>
         /// <returns>A task returning the generated mask as an NDArray.</returns>
-        public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string inputImagePath, int fadeWidth = 30, CancellationToken cancellationToken = default)
+        public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string inputImagePath, BackgroundMaskOptions options, CancellationToken cancellationToken = default)
         {
             return Task.Run(() =>
             {
@@ -402,7 +404,7 @@ namespace PixelsorterClassLib.Masks
                 cancellationToken.ThrowIfCancellationRequested();
                 LoadModel();
                 cancellationToken.ThrowIfCancellationRequested();
-                (var mask, var invertedMask) = CreateMask(inputImage, fadeWidth);
+                (var mask, var invertedMask) = CreateMask(inputImage, options.fadeWidth);
                 return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
             }, cancellationToken);
         }

--- a/PixelsorterClassLib/Masks/BackgroundMask.cs
+++ b/PixelsorterClassLib/Masks/BackgroundMask.cs
@@ -13,7 +13,16 @@ namespace PixelsorterClassLib.Masks
     /// Represents options for configuring a background mask with a specified fade width.
     /// </summary>
     /// <param name="FadeWidth">The width, in pixels, over which the background mask fades. Must be a non-negative integer.</param>
-    public record BackgroundMaskOptions(int FadeWidth) : MaskOptions;
+    public record BackgroundMaskOptions : MaskOptions
+    {
+        public int FadeWidth { get; init; }
+
+        public BackgroundMaskOptions(int fadeWidth)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(fadeWidth);
+            FadeWidth = fadeWidth;
+        }
+    }
 
     /// <summary>
     /// Provides functionality to generate a mask from an input image using a pre-trained model.

--- a/PixelsorterClassLib/Masks/BackgroundMask.cs
+++ b/PixelsorterClassLib/Masks/BackgroundMask.cs
@@ -13,14 +13,19 @@ namespace PixelsorterClassLib.Masks
     /// Represents options for configuring a background mask with a specified fade width.
     /// </summary>
     /// <param name="FadeWidth">The width, in pixels, over which the background mask fades. Must be a non-negative integer.</param>
+    /// <param name="ConfidenceThreshold"> The confidence threshold for the model to choose what is Background and what is foreground. </param>
     public record BackgroundMaskOptions : MaskOptions
     {
         public int FadeWidth { get; init; }
+        public float ConfidenceThreshold { get; init; }
 
-        public BackgroundMaskOptions(int fadeWidth)
+        public BackgroundMaskOptions(int fadeWidth, float confidenceThreshold = 0.5f)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(fadeWidth);
             FadeWidth = fadeWidth;
+
+            if (confidenceThreshold <= 0 || confidenceThreshold >= 1) throw new ArgumentOutOfRangeException("ConfidenceThreshold must be in range (0,1)");
+            ConfidenceThreshold = confidenceThreshold;
         }
     }
 
@@ -36,6 +41,7 @@ namespace PixelsorterClassLib.Masks
         private static InferenceSession? _session;
         private static string? _inputName;
         private static string? _outputName;
+        private float _confidenceThreshold = 0.5f;
         private static readonly object _sessionLock = new();
         private const int ModelInputSize = 1024;
         private static readonly string ModelCachePath = Path.Combine(
@@ -363,7 +369,7 @@ namespace PixelsorterClassLib.Masks
                     {
                         float normalizedX = originalWidth > 1 ? x / (float)(originalWidth - 1) : 0f;
                         var maskValue = GetMaskValueBilinear(outputTensor, maskHeight, maskWidth, normalizedY, normalizedX, min, max);
-                        byte grayValue = maskValue < 0.5f ? (byte)255 : (byte)0;
+                        byte grayValue = maskValue < this._confidenceThreshold ? (byte)255 : (byte)0;
                         maskRow[x] = new L8(grayValue);
                         invertedMaskRow[x] = new L8(grayValue == 255 ? (byte)0 : (byte)255);
                     }
@@ -393,6 +399,7 @@ namespace PixelsorterClassLib.Masks
         public override (NDArray mask, NDArray invertedMask) GetMask(String inputImagePath, BackgroundMaskOptions options)
         {
             using var inputImage = LoadImage(inputImagePath);
+            this._confidenceThreshold = options.ConfidenceThreshold;
             LoadModel();
             (var mask, var invertedMask) = CreateMask(inputImage, options.FadeWidth);
             return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
@@ -410,6 +417,7 @@ namespace PixelsorterClassLib.Masks
             return Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                this._confidenceThreshold = options.ConfidenceThreshold;
                 using var inputImage = LoadImage(inputImagePath);
                 cancellationToken.ThrowIfCancellationRequested();
                 LoadModel();

--- a/PixelsorterClassLib/Masks/CannyMask.cs
+++ b/PixelsorterClassLib/Masks/CannyMask.cs
@@ -6,7 +6,10 @@ using SixLabors.ImageSharp.Processing;
 
 namespace PixelsorterClassLib.Masks
 {
-    public class CannyMask : Mask
+
+    public record CannyMaskOptions(float threshold) : MaskOptions;
+    
+    public class CannyMask : Mask<CannyMaskOptions>
     {
 
         /// <summary>
@@ -22,13 +25,13 @@ namespace PixelsorterClassLib.Masks
         /// </summary>
         /// <param name="fadeWidth">The fade width percentage to set as the threshold. Must be in (0, 100].</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="fadeWidth"/> is not in (0, 100].</exception>
-        private void SetThreshold(int fadeWidth)
+        private void SetThreshold(float _threshold)
         {
-            if (fadeWidth <= 0 || fadeWidth > 100)
+            if (_threshold <= 0 || _threshold > 1)
             {
                 throw new ArgumentException("Threshold needs to be betwenn range (0, 100] (%)");
             }
-            threshold = fadeWidth / 100f;
+            threshold = _threshold;
         }
 
         /// <summary>
@@ -73,9 +76,9 @@ namespace PixelsorterClassLib.Masks
         /// <param name="fadeWidth">The threshold for the canny edge detection in percentage in range (0, 100]. Defaults to 30%</param>
         /// <returns>A tuple containing two NDArray objects: the first is the mask representing detected edges, and the second is
         /// the inverted mask. Both arrays will have the same dimensions as the input image.</returns>
-        public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, int fadeWidth = 30)
+        public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, CannyMaskOptions options)
         {
-            SetThreshold(fadeWidth);
+            SetThreshold(options.threshold);
             using var image = LoadImage(imagePath);
             (var mask, var invertedMask) = CreateCannyMask(image);
             return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
@@ -92,11 +95,11 @@ namespace PixelsorterClassLib.Masks
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the mask generation operation.</param>
         /// <returns>A task that represents the asynchronous operation. The result contains a tuple with the mask and inverted
         /// mask as NDArray objects.</returns>
-        public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string imagePath, int fadeWidth = 30, CancellationToken cancellationToken = default)
+        public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string imagePath, CannyMaskOptions options, CancellationToken cancellationToken = default)
         {
             return Task.Run(() =>
             {
-                SetThreshold(fadeWidth);
+                SetThreshold(options.threshold);
                 cancellationToken.ThrowIfCancellationRequested();
                 using var image = LoadImage(imagePath);
                 cancellationToken.ThrowIfCancellationRequested();

--- a/PixelsorterClassLib/Masks/CannyMask.cs
+++ b/PixelsorterClassLib/Masks/CannyMask.cs
@@ -12,7 +12,15 @@ namespace PixelsorterClassLib.Masks
     /// </summary>
     /// <param name="Threshold">The threshold value used to determine edge sensitivity. Higher values result in fewer detected edges. Must be
     /// non-negative.</param>
-    public record CannyMaskOptions(float Threshold) : MaskOptions;
+    public record CannyMaskOptions : MaskOptions
+    {
+        public float Threshold { get; init; }
+
+        public CannyMaskOptions(float threshold)
+        {
+            if (threshold < 0 || threshold >= 1) throw new ArgumentException("Threshold needs to be betwenn range (0, 1] (0,100 %)");
+        }
+    }
     
     public class CannyMask : Mask<CannyMaskOptions>
     {
@@ -24,20 +32,6 @@ namespace PixelsorterClassLib.Masks
         /// and should be in the range (0, 1].
         /// </summary>
         private float threshold = 0.3f;
-
-        /// <summary>
-        /// Sets the threshold value used for edge detection.
-        /// </summary>
-        /// <param name="_threshold">The threshold value to set. Must be in the range (0, 1].</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="_threshold"/> is not in (0, 1].</exception>
-        private void SetThreshold(float _threshold)
-        {
-            if (_threshold <= 0 || _threshold > 1)
-            {
-                throw new ArgumentException("Threshold needs to be betwenn range (0, 100] (%)");
-            }
-            threshold = _threshold;
-        }
 
         /// <summary>
         /// Generates a binary mask and its inverted counterpart from the specified image using Canny-like edge
@@ -81,7 +75,7 @@ namespace PixelsorterClassLib.Masks
         /// the inverted mask. Both arrays will have the same dimensions as the input image.</returns>
         public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, CannyMaskOptions options)
         {
-            SetThreshold(options.Threshold);
+            this.threshold = options.Threshold;
             using var image = LoadImage(imagePath);
             (var mask, var invertedMask) = CreateCannyMask(image);
             return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
@@ -101,7 +95,7 @@ namespace PixelsorterClassLib.Masks
         {
             return Task.Run(() =>
             {
-                SetThreshold(options.Threshold);
+                this.threshold = options.Threshold;
                 cancellationToken.ThrowIfCancellationRequested();
                 using var image = LoadImage(imagePath);
                 cancellationToken.ThrowIfCancellationRequested();

--- a/PixelsorterClassLib/Masks/CannyMask.cs
+++ b/PixelsorterClassLib/Masks/CannyMask.cs
@@ -1,4 +1,4 @@
-﻿using NumSharp;
+using NumSharp;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
@@ -7,6 +7,11 @@ using SixLabors.ImageSharp.Processing;
 namespace PixelsorterClassLib.Masks
 {
 
+    /// <summary>
+    /// Specifies options for generating a mask using the Canny edge detection algorithm.
+    /// </summary>
+    /// <param name="threshold">The threshold value used to determine edge sensitivity. Higher values result in fewer detected edges. Must be
+    /// non-negative.</param>
     public record CannyMaskOptions(float threshold) : MaskOptions;
     
     public class CannyMask : Mask<CannyMaskOptions>
@@ -15,16 +20,16 @@ namespace PixelsorterClassLib.Masks
         /// <summary>
         /// The threshold value for the binary thresholding step in the Canny edge detection process. 
         /// This value determines the sensitivity of edge detection, with lower values resulting in more edges being detected 
-        /// and higher values resulting in fewer edges. The threshold is calculated as a percentage of the maximum pixel intensity (255) 
-        /// and is set based on the provided fadeWidth parameter, which should be between 0 and 100.
+        /// and higher values resulting in fewer edges. The threshold is set via <see cref="CannyMaskOptions.threshold"/> 
+        /// and should be in the range (0, 1].
         /// </summary>
         private float threshold = 0.3f;
 
         /// <summary>
-        /// Sets the threshold value used for fade calculations as a percentage.
+        /// Sets the threshold value used for edge detection.
         /// </summary>
-        /// <param name="fadeWidth">The fade width percentage to set as the threshold. Must be in (0, 100].</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="fadeWidth"/> is not in (0, 100].</exception>
+        /// <param name="_threshold">The threshold value to set. Must be in the range (0, 1].</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="_threshold"/> is not in (0, 1].</exception>
         private void SetThreshold(float _threshold)
         {
             if (_threshold <= 0 || _threshold > 1)
@@ -67,13 +72,11 @@ namespace PixelsorterClassLib.Masks
         }
 
         /// <summary>
-        /// Generates a mask and an inverted mask from the specified image using edge detection, with optional fading at
-        /// the mask boundaries.
+        /// Generates a mask and an inverted mask from the specified image using edge detection.
         /// </summary>
-        /// <remarks>The method uses Canny edge detection to create the masks. Increasing the fade width
-        /// softens the mask boundaries, which can be useful for blending or compositing operations.</remarks>
+        /// <remarks>The method uses Canny edge detection to create the masks.</remarks>
         /// <param name="imagePath">The file path to the image from which the mask will be generated. Cannot be null or empty.</param>
-        /// <param name="fadeWidth">The threshold for the canny edge detection in percentage in range (0, 100]. Defaults to 30%</param>
+        /// <param name="options">The options controlling mask generation, including the edge detection threshold.</param>
         /// <returns>A tuple containing two NDArray objects: the first is the mask representing detected edges, and the second is
         /// the inverted mask. Both arrays will have the same dimensions as the input image.</returns>
         public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, CannyMaskOptions options)
@@ -85,13 +88,12 @@ namespace PixelsorterClassLib.Masks
         }
 
         /// <summary>
-        /// Generates a binary mask and its inverted mask for the specified image using edge detection, with optional
-        /// fade width adjustment.
+        /// Generates a binary mask and its inverted mask for the specified image using edge detection.
         /// </summary>
         /// <remarks>The mask is generated using a Canny edge detection algorithm. The operation is
         /// performed asynchronously and supports cancellation.</remarks>
         /// <param name="imagePath">The file path of the image to process. Must refer to a valid image file.</param>
-        /// <param name="fadeWidth">The threshold for the canny edge detection in percentage in range (0, 100]. Defaults to 30%</param>
+        /// <param name="options">The options controlling mask generation, including the edge detection threshold.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the mask generation operation.</param>
         /// <returns>A task that represents the asynchronous operation. The result contains a tuple with the mask and inverted
         /// mask as NDArray objects.</returns>

--- a/PixelsorterClassLib/Masks/CannyMask.cs
+++ b/PixelsorterClassLib/Masks/CannyMask.cs
@@ -10,9 +10,9 @@ namespace PixelsorterClassLib.Masks
     /// <summary>
     /// Specifies options for generating a mask using the Canny edge detection algorithm.
     /// </summary>
-    /// <param name="threshold">The threshold value used to determine edge sensitivity. Higher values result in fewer detected edges. Must be
+    /// <param name="Threshold">The threshold value used to determine edge sensitivity. Higher values result in fewer detected edges. Must be
     /// non-negative.</param>
-    public record CannyMaskOptions(float threshold) : MaskOptions;
+    public record CannyMaskOptions(float Threshold) : MaskOptions;
     
     public class CannyMask : Mask<CannyMaskOptions>
     {
@@ -20,7 +20,7 @@ namespace PixelsorterClassLib.Masks
         /// <summary>
         /// The threshold value for the binary thresholding step in the Canny edge detection process. 
         /// This value determines the sensitivity of edge detection, with lower values resulting in more edges being detected 
-        /// and higher values resulting in fewer edges. The threshold is set via <see cref="CannyMaskOptions.threshold"/> 
+        /// and higher values resulting in fewer edges. The threshold is set via <see cref="CannyMaskOptions.Threshold"/> 
         /// and should be in the range (0, 1].
         /// </summary>
         private float threshold = 0.3f;
@@ -81,7 +81,7 @@ namespace PixelsorterClassLib.Masks
         /// the inverted mask. Both arrays will have the same dimensions as the input image.</returns>
         public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, CannyMaskOptions options)
         {
-            SetThreshold(options.threshold);
+            SetThreshold(options.Threshold);
             using var image = LoadImage(imagePath);
             (var mask, var invertedMask) = CreateCannyMask(image);
             return (ConvertMaskToNdArray(mask), ConvertMaskToNdArray(invertedMask));
@@ -101,7 +101,7 @@ namespace PixelsorterClassLib.Masks
         {
             return Task.Run(() =>
             {
-                SetThreshold(options.threshold);
+                SetThreshold(options.Threshold);
                 cancellationToken.ThrowIfCancellationRequested();
                 using var image = LoadImage(imagePath);
                 cancellationToken.ThrowIfCancellationRequested();

--- a/PixelsorterClassLib/Masks/CannyMask.cs
+++ b/PixelsorterClassLib/Masks/CannyMask.cs
@@ -19,6 +19,7 @@ namespace PixelsorterClassLib.Masks
         public CannyMaskOptions(float threshold)
         {
             if (threshold < 0 || threshold >= 1) throw new ArgumentException("Threshold needs to be betwenn range (0, 1] (0,100 %)");
+            Threshold = threshold;
         }
     }
     

--- a/PixelsorterClassLib/Masks/LuminanceMask.cs
+++ b/PixelsorterClassLib/Masks/LuminanceMask.cs
@@ -13,16 +13,16 @@ namespace PixelsorterClassLib.Masks
     /// <summary>
     /// Represents options for generating a mask based on luminance values, using a specified threshold multiplier.
     /// </summary>
-    /// <param name="thresholdMultiplier">The multiplier applied to the luminance threshold to determine which pixels are included in the mask. Must be a
+    /// <param name="ThresholdMultiplier">The multiplier applied to the luminance threshold to determine which pixels are included in the mask. Must be a
     /// non-negative value.</param>
-    public record LuminanceMaskOptions(float thresholdMultiplier) : MaskOptions; 
+    public record LuminanceMaskOptions(float ThresholdMultiplier) : MaskOptions; 
 
     /// <summary>
     /// Provides a mask based on the luminance values of an image, generating binary masks by thresholding pixel
     /// intensities.
     /// </summary>
     /// <remarks>The luminance threshold is dynamically calculated based on the minimum and maximum pixel
-    /// values in the image and is influenced by the <see cref="LuminanceMaskOptions.thresholdMultiplier"/>. 
+    /// values in the image and is influenced by the <see cref="LuminanceMaskOptions.ThresholdMultiplier"/>. 
     /// Thread safety is not guaranteed; concurrent use of the same instance is not supported.</remarks>
     public class LuminanceMask : Mask<LuminanceMaskOptions>
     {
@@ -86,7 +86,7 @@ namespace PixelsorterClassLib.Masks
         public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, LuminanceMaskOptions options)
         {
             using var image = LoadImage(imagePath);
-            this.thresholdMultiplier = options.thresholdMultiplier;
+            this.thresholdMultiplier = options.ThresholdMultiplier;
             return CreateLuminanceMask(image);
         }
 
@@ -96,7 +96,7 @@ namespace PixelsorterClassLib.Masks
             {
                 using var image = LoadImage(imagePath);
                 cancellationToken.ThrowIfCancellationRequested();
-                this.thresholdMultiplier = options.thresholdMultiplier;
+                this.thresholdMultiplier = options.ThresholdMultiplier;
                 return CreateLuminanceMask(image);
             }, cancellationToken);
         }

--- a/PixelsorterClassLib/Masks/LuminanceMask.cs
+++ b/PixelsorterClassLib/Masks/LuminanceMask.cs
@@ -15,7 +15,18 @@ namespace PixelsorterClassLib.Masks
     /// </summary>
     /// <param name="ThresholdMultiplier">The multiplier applied to the luminance threshold to determine which pixels are included in the mask. Must be a
     /// non-negative value.</param>
-    public record LuminanceMaskOptions(float ThresholdMultiplier) : MaskOptions; 
+    public record LuminanceMaskOptions : MaskOptions
+    {
+        public float ThresholdMultiplier {  get; init; }
+
+        public LuminanceMaskOptions(float thresholdMultiplier)
+        {
+            if (thresholdMultiplier < 0 || thresholdMultiplier >= 1) throw new ArgumentException("ThresholdMultiplier needs to be betwenn range (0, 1] (0,100 %)");
+            ThresholdMultiplier = thresholdMultiplier;
+        }
+
+        
+    } 
 
     /// <summary>
     /// Provides a mask based on the luminance values of an image, generating binary masks by thresholding pixel

--- a/PixelsorterClassLib/Masks/LuminanceMask.cs
+++ b/PixelsorterClassLib/Masks/LuminanceMask.cs
@@ -1,4 +1,4 @@
-﻿using NumSharp;
+using NumSharp;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
@@ -10,6 +10,11 @@ namespace PixelsorterClassLib.Masks
 {
 
 
+    /// <summary>
+    /// Represents options for generating a mask based on luminance values, using a specified threshold multiplier.
+    /// </summary>
+    /// <param name="thresholdMultiplier">The multiplier applied to the luminance threshold to determine which pixels are included in the mask. Must be a
+    /// non-negative value.</param>
     public record LuminanceMaskOptions(float thresholdMultiplier) : MaskOptions; 
 
     /// <summary>
@@ -17,8 +22,8 @@ namespace PixelsorterClassLib.Masks
     /// intensities.
     /// </summary>
     /// <remarks>The luminance threshold is dynamically calculated based on the minimum and maximum pixel
-    /// values in the image and is influenced by the specified fade width. Thread safety is not guaranteed; concurrent
-    /// use of the same instance is not supported.</remarks>
+    /// values in the image and is influenced by the <see cref="LuminanceMaskOptions.thresholdMultiplier"/>. 
+    /// Thread safety is not guaranteed; concurrent use of the same instance is not supported.</remarks>
     public class LuminanceMask : Mask<LuminanceMaskOptions>
     {
 

--- a/PixelsorterClassLib/Masks/LuminanceMask.cs
+++ b/PixelsorterClassLib/Masks/LuminanceMask.cs
@@ -8,6 +8,10 @@ using System.Text;
 
 namespace PixelsorterClassLib.Masks
 {
+
+
+    public record LuminanceMaskOptions(float thresholdMultiplier) : MaskOptions; 
+
     /// <summary>
     /// Provides a mask based on the luminance values of an image, generating binary masks by thresholding pixel
     /// intensities.
@@ -15,7 +19,7 @@ namespace PixelsorterClassLib.Masks
     /// <remarks>The luminance threshold is dynamically calculated based on the minimum and maximum pixel
     /// values in the image and is influenced by the specified fade width. Thread safety is not guaranteed; concurrent
     /// use of the same instance is not supported.</remarks>
-    public class LuminanceMask : Mask
+    public class LuminanceMask : Mask<LuminanceMaskOptions>
     {
 
         /// <summary>
@@ -74,20 +78,20 @@ namespace PixelsorterClassLib.Masks
             return Image.Load<L8>(inputImagePath) ?? throw new InvalidOperationException("Failed to load the input image.");
         }
 
-        public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, int fadeWidth)
+        public override (NDArray mask, NDArray invertedMask) GetMask(string imagePath, LuminanceMaskOptions options)
         {
             using var image = LoadImage(imagePath);
-            this.thresholdMultiplier = fadeWidth / 100f;
+            this.thresholdMultiplier = options.thresholdMultiplier;
             return CreateLuminanceMask(image);
         }
 
-        public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string imagePath, int fadeWidth, CancellationToken cancellationToken = default)
+        public override Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(string imagePath, LuminanceMaskOptions options, CancellationToken cancellationToken = default)
         {
             return Task.Run(() =>
             {
                 using var image = LoadImage(imagePath);
                 cancellationToken.ThrowIfCancellationRequested();
-                this.thresholdMultiplier = fadeWidth / 100f;
+                this.thresholdMultiplier = options.thresholdMultiplier;
                 return CreateLuminanceMask(image);
             }, cancellationToken);
         }

--- a/PixelsorterClassLib/Masks/Mask.cs
+++ b/PixelsorterClassLib/Masks/Mask.cs
@@ -8,7 +8,7 @@ namespace PixelsorterClassLib.Masks
 
     public abstract record MaskOptions();
 
-    public abstract class Mask
+    public abstract class Mask<TOptions> where TOptions : MaskOptions
     {
         /// <summary>
         /// Gets a value indicating whether the object is ready to be used.
@@ -29,9 +29,10 @@ namespace PixelsorterClassLib.Masks
             return Task.FromResult(true);
         }
 
-        public abstract (NDArray mask, NDArray invertedMask) GetMask(String imagePath, MaskOptions options);
+        public abstract (NDArray mask, NDArray invertedMask) GetMask(String imagePath, TOptions options);
 
-        public abstract Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(String imagePath, MaskOptions options, CancellationToken cancellationToken = default);
+        public abstract Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(String imagePath, TOptions options, CancellationToken cancellationToken = default);
+
 
         /// <summary>
         /// Converts a single-channel grayscale image mask to an NDArray with shape (height, width, 1).

--- a/PixelsorterClassLib/Masks/Mask.cs
+++ b/PixelsorterClassLib/Masks/Mask.cs
@@ -4,6 +4,10 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PixelsorterClassLib.Masks
 {
+
+
+    public abstract record MaskOptions();
+
     public abstract class Mask
     {
         /// <summary>
@@ -25,9 +29,9 @@ namespace PixelsorterClassLib.Masks
             return Task.FromResult(true);
         }
 
-        public abstract (NDArray mask, NDArray invertedMask) GetMask(String imagePath, int fadeWidth);
+        public abstract (NDArray mask, NDArray invertedMask) GetMask(String imagePath, MaskOptions options);
 
-        public abstract Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(String imagePath, int fadeWidth, CancellationToken cancellationToken = default);
+        public abstract Task<(NDArray mask, NDArray invertedMask)> GetMaskAsync(String imagePath, MaskOptions options, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Converts a single-channel grayscale image mask to an NDArray with shape (height, width, 1).

--- a/PixelsorterClassLib/Masks/Mask.cs
+++ b/PixelsorterClassLib/Masks/Mask.cs
@@ -5,9 +5,22 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace PixelsorterClassLib.Masks
 {
 
-
+    /// <summary>
+    /// Represents the base class for specifying options used to configure masking behavior.
+    /// </summary>
+    /// <remarks>Inherit from this record to define specific masking options for use with masking operations
+    /// or components. This type is intended to be extended to provide concrete option sets.</remarks>
     public abstract record MaskOptions();
 
+    /// <summary>
+    /// Provides a base class for image mask operations that support optional model-based processing and configurable
+    /// options.
+    /// </summary>
+    /// <remarks>This abstract class defines the contract for mask generation, including synchronous and
+    /// asynchronous methods for obtaining masks from images. Implementations may require downloading a model before
+    /// use; the readiness and download behavior are exposed via the IsReadyToUse property and DownloadModel method.
+    /// Derived classes should specify the requirements and behavior for their specific mask generation logic.</remarks>
+    /// <typeparam name="TOptions">The type of options used to configure the mask operation. Must inherit from MaskOptions.</typeparam>
     public abstract class Mask<TOptions> where TOptions : MaskOptions
     {
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ string outputPath = "output.jpg";
 // 1. Load the image into an NDArray
 NDArray imageData = Image.LoadImage(inputPath);
 
-// 2. Generate a binary mask using ML inference
-NDArray mask = new Mask().GetMask(inputPath, 50);
+// 2. Get mask options
 
-// 3. Sort image by warmth, left to right, within the boundaries of the mask
+MaskOptions<BackgroundMaskOptions> options = new BackgroundMaskOptions(0.5f)
+
+// Simpler using var
+// var options = new BackgroundMask(0.5f)
+
+
+// 3. Generate a binary mask using ML inference
+NDArray mask = new BackgroundMask().GetMask(inputPath, options);
+
+// 4. Sort image by warmth, left to right, within the boundaries of the mask
 NDArray sortedData = Sorter.SortImage(imageData, SortBy.Warmth(), SortDirections.RowLeftToRight, mask);
 
-// 4. Save the sorted image to disk
+// 5. Save the sorted image to disk
 Image.SaveImage(sortedData, outputPath);
 ```
 
@@ -61,6 +69,7 @@ var criteria = SortBy.GetAllSortingCriteria();
 
 - **BackgroundMask:** Generates a binary mask isolating the background of an image.
 - **CannyMask:** Creates a binary mask based on edge detection using a Canny like algorithm.
+- **LuminanceMask** Creates a mask based on the luminance of the Image.
 - **MaskCombiner:** Combines multiple binary masks into a single mask.
 
 


### PR DESCRIPTION
## Description
`GetMask`and `GetMaskAsync` are now generic to use `MaskOptions` to allow diffrent types of masks to have their own parameters.

Fixes # (issue)
#14 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested with Unit Tests (Required)
- [x] Tested with ConsoleApp output
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new dependencies, they use MIT/Apache 2.0 licenses or their compatibility is explicitly mentioned in the description
