### PR TITLE
Downscale

### DIFF
--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -19,26 +19,31 @@ internal class Program
 {
     private static void Main(string[] args)
     {
-
         String inputImagePath = "D:\\Documents\\codeing\\PixelsorterProject\\PixelsorterClassLib\\ConsoleApp\\examples\\alone-4480442.jpg";
         String outputDirectory = "D:\\Documents\\codeing\\PixelsorterProject\\PixelsorterClassLib\\ConsoleApp\\examples\\";
 
-        var img = PixelsorterClassLib.Core.Image.LoadImage(inputImagePath);
+        var sortBy = SortBy.Saturation();
+        var direction = SortDirections.RowRightToLeft;
 
+        var warmup = PixelsorterClassLib.Core.Image.LoadImage(inputImagePath, KnownResamplers.NearestNeighbor);
+        PixelsorterClassLib.Core.Sorter.SortImage(warmup.Item1, sortBy, direction);
 
-        var masker = new ChunkMask();
+        var downscaleWatch = System.Diagnostics.Stopwatch.StartNew();
+        var (downscaledImage, downscaledSize) = PixelsorterClassLib.Core.Image.LoadImage(inputImagePath, KnownResamplers.NearestNeighbor);
+        var downscaledSorted = PixelsorterClassLib.Core.Sorter.SortImage(downscaledImage, sortBy, direction);
+        PixelsorterClassLib.Core.Image.SaveImage(downscaledSorted, $"{outputDirectory}downscaled_upscaled_sorted.png", KnownResamplers.NearestNeighbor, downscaledSize);
 
+        downscaleWatch.Stop();
 
-        (var j, var k) = masker.GetMask(inputImagePath, new ChunkMaskOptions(1500, 3500, SortDirections.ColumnBottomToTop));
+        PixelsorterClassLib.Core.Image.SaveImage(downscaledSorted, $"{outputDirectory}downscaled_sorted.png");
 
-        var foo = Sorter.SortImage(img, SortBy.Warmth(), SortDirections.ColumnBottomToTop, j);
-        var voo = Sorter.SortImage(img, SortBy.Warmth(), SortDirections.ColumnBottomToTop, k);
+        var fullResWatch = System.Diagnostics.Stopwatch.StartNew();
+        var (fullResImage, fullResSize) = PixelsorterClassLib.Core.Image.LoadImage(inputImagePath);
+        var fullResSorted = PixelsorterClassLib.Core.Sorter.SortImage(fullResImage, sortBy, direction);
+        PixelsorterClassLib.Core.Image.SaveImage(fullResSorted, $"{outputDirectory}full_res_sorted.png");
+        fullResWatch.Stop();
 
-
-
-        PixelsorterClassLib.Core.Image.SaveImage(foo, $"{outputDirectory}_j.jpg");
-        PixelsorterClassLib.Core.Image.SaveImage(voo, $"{outputDirectory}_k.jpg");
-
-
+        Console.WriteLine($"Full resolution sort: {fullResWatch.ElapsedMilliseconds} ms (loaded {fullResSize.width}x{fullResSize.height})");
+        Console.WriteLine($"Downscaled and upscaled after sorting sort: {downscaleWatch.ElapsedMilliseconds} ms");
     }
 }

--- a/PixelsorterClassLib/Core/Image.cs
+++ b/PixelsorterClassLib/Core/Image.cs
@@ -28,7 +28,7 @@ public class Image
     /// </summary>
     /// <param name="path">The file path of the image to load.</param>
     /// <param name="resampler">Optional resampler used to resize the image during loading if it is larger then 1080p.</param>
-    /// <returns>A 3D NumSharp array representing the image in HSL color space and a tuple containing the image's width and height.</returns>
+    /// <returns>A 3D NumSharp array representing the image in HSL color space and a tuple containing the image's original width and height.</returns>
     public static (NDArray, (int width, int height)) LoadImage(string path, IResampler? resampler = null)
     {
         using var image = SixLabors.ImageSharp.Image.Load<Rgb24>(path);

--- a/PixelsorterClassLib/Core/Image.cs
+++ b/PixelsorterClassLib/Core/Image.cs
@@ -3,6 +3,9 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.ColorSpaces.Conversion;
+using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.Processing;
 
 namespace PixelsorterClassLib.Core;
 
@@ -15,17 +18,39 @@ namespace PixelsorterClassLib.Core;
 public class Image
 {
 
+    const int MaxLongSide = 1920;
+    const int MaxShortSide = 1080;
+
+
     /// <summary>
     /// Loads an image from the specified file path and returns it as a 3D NumSharp array (height x width x channels) in HSL color space. 
     /// The method should handle various image formats and convert them to a consistent format (e.g., RGBA) for processing.
     /// </summary>
-    /// <param name="path"></param>
-    /// <returns></returns>
-    public static NDArray LoadImage(string path)
+    /// <param name="path">The file path of the image to load.</param>
+    /// <param name="resampler">Optional resampler used to resize the image during loading if it is larger then 1080p.</param>
+    /// <returns>A 3D NumSharp array representing the image in HSL color space and a tuple containing the image's width and height.</returns>
+    public static (NDArray, (int width, int height)) LoadImage(string path, IResampler? resampler = null)
     {
         using var image = SixLabors.ImageSharp.Image.Load<Rgb24>(path);
+        image.Mutate(x => x.AutoOrient());
         int height = image.Height;
         int width = image.Width;
+
+        if (resampler != null && (Math.Max(width, height) > MaxLongSide || Math.Min(width, height) > MaxShortSide))
+        {
+            bool isLandscape = width >= height;
+            Size targetSize = isLandscape
+                ? new Size(MaxLongSide, MaxShortSide)
+                : new Size(MaxShortSide, MaxLongSide);
+
+            image.Mutate(x => x.Resize(new ResizeOptions
+            {
+                Mode = ResizeMode.Max,
+                Size = targetSize,
+                Sampler = resampler,
+                Compand = true
+            }));
+        }
 
         // Allocate flat byte array for direct access
         float[] data = new float[height * width * 3];
@@ -52,7 +77,7 @@ public class Image
         });
 
         // Create NDArray from byte array and reshape to 3D
-        return np.array(data).reshape(new Shape(height, width, 3));
+        return (np.array(data).reshape(new Shape(height, width, 3)), (width, height));
     }
 
 

--- a/PixelsorterClassLib/Core/Image.cs
+++ b/PixelsorterClassLib/Core/Image.cs
@@ -150,7 +150,7 @@ public class Image
     /// <param name="path">The file path where the image will be saved.</param>
     /// <param name="resampler">The resampler to use for resizing the image.</param>
     /// <param name="size">The target size for resizing the image.</param>
-    public static void SaveImage(NDArray data, string path, IResampler? resampler, (int width, int height)? size)
+    public static void SaveImage(NDArray data, string path, IResampler? resampler = null, (int width, int height)? size = null)
     {
 
 

--- a/PixelsorterClassLib/Core/Image.cs
+++ b/PixelsorterClassLib/Core/Image.cs
@@ -35,6 +35,7 @@ public class Image
         image.Mutate(x => x.AutoOrient());
         int height = image.Height;
         int width = image.Width;
+        (int, int) originalSize = (width, height);
 
         if (resampler != null && (Math.Max(width, height) > MaxLongSide || Math.Min(width, height) > MaxShortSide))
         {
@@ -50,6 +51,9 @@ public class Image
                 Sampler = resampler,
                 Compand = true
             }));
+            
+            width = image.Width;
+            height = image.Height;
         }
 
         // Allocate flat byte array for direct access
@@ -77,7 +81,7 @@ public class Image
         });
 
         // Create NDArray from byte array and reshape to 3D
-        return (np.array(data).reshape(new Shape(height, width, 3)), (width, height));
+        return (np.array(data).reshape(new Shape(height, width, 3)), originalSize);
     }
 
 
@@ -171,7 +175,7 @@ public class Image
                     Sampler = resampler,
                     Compand = true
                 }));
-            } else if (resampler == null ^ size.HasValue)
+            } else if (resampler != null ^ size.HasValue)
             {
                 throw new ArgumentException("Both resampler and size must be provided together or both must be null.");
             }

--- a/PixelsorterClassLib/Core/Image.cs
+++ b/PixelsorterClassLib/Core/Image.cs
@@ -146,9 +146,11 @@ public class Image
     /// Saves a 3D NumSharp array (height x width x channels) as an image file at the specified path. 
     /// The method should handle the conversion from the NumSharp array format back to an image format and support various output formats based on the file extension provided in the path.
     /// </summary>
-    /// <param name="data"></param>
-    /// <param name="path"></param>
-    public static void SaveImage(NDArray data, string path)
+    /// <param name="data">The NumSharp array containing image data.</param>
+    /// <param name="path">The file path where the image will be saved.</param>
+    /// <param name="resampler">The resampler to use for resizing the image.</param>
+    /// <param name="size">The target size for resizing the image.</param>
+    public static void SaveImage(NDArray data, string path, IResampler? resampler, (int width, int height)? size)
     {
 
 
@@ -159,6 +161,20 @@ public class Image
         }
 
         using var image = NdarrayToImgData(data);
+
+            if (resampler != null && size.HasValue)
+            {
+                image.Mutate(x => x.Resize(new ResizeOptions
+                {
+                    Mode = ResizeMode.Max,
+                    Size = new Size(size.Value.width, size.Value.height),
+                    Sampler = resampler,
+                    Compand = true
+                }));
+            } else if (resampler == null ^ size.HasValue)
+            {
+                throw new ArgumentException("Both resampler and size must be provided together or both must be null.");
+            }
 
         using var outputStream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
         image.SaveAsPng(outputStream);

--- a/PixelsorterTests/ImageTests/ImageScalingTests.cs
+++ b/PixelsorterTests/ImageTests/ImageScalingTests.cs
@@ -1,0 +1,80 @@
+﻿using PixelsorterClassLib.Core;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+
+namespace Pixelsorter.Tests.ImageTests
+{
+    public class ImageScalingTests
+    {
+        [Fact]
+        public void Scale4kLandscape_ShouldScaleTo1080p()
+        {
+            var inPath = ImageTestHelpers.CreateTestImage(".png", 3, 3840, 2160);
+            try
+            {
+                var (image, _) = Image.LoadImage(inPath, KnownResamplers.Bicubic);
+                var outImg = Image.NdarrayToImgData(image);
+                Assert.Equal(1920, outImg.Width);
+                Assert.Equal(1080, outImg.Height);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Exception thrown during test: {ex}");
+
+            }
+            finally
+            {
+                if (File.Exists(inPath)) File.Delete(inPath);
+
+            }
+        }
+
+        [Fact]
+        public void Scale4kImagdownAndUpAgain_ShouldBe4k()
+        {
+            var inPath = ImageTestHelpers.CreateTestImage(".png", 3, 3840, 2160);
+            var outPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
+            try
+            {
+                var (image, size) = Image.LoadImage(inPath, KnownResamplers.Bicubic);
+                Image.SaveImage(image, outPath, KnownResamplers.Bicubic, size);
+
+                var savedImage = SixLabors.ImageSharp.Image.Load<Rgb24>(outPath);
+                Assert.Equal(3840, savedImage.Width);
+                Assert.Equal(2160, savedImage.Height);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Exception thrown during test: {ex}");
+            }
+            finally
+            {
+                if (File.Exists(inPath)) File.Delete(inPath);
+                if (File.Exists(outPath)) File.Delete(outPath);
+
+            }
+        }
+
+        [Fact]
+        public void Scale720pImage_ShouldNotScale()
+        {
+            var inPath = ImageTestHelpers.CreateTestImage(".png", 3, 1280, 720);
+            try
+            {
+                var (image, _) = Image.LoadImage(inPath, KnownResamplers.Bicubic);
+                var outImg = Image.NdarrayToImgData(image);
+                Assert.Equal(1280, outImg.Width);
+                Assert.Equal(720, outImg.Height);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Exception thrown during test: {ex}");
+            }
+            finally
+            {
+                if (File.Exists(inPath)) File.Delete(inPath);
+            }
+        }
+    }
+}

--- a/PixelsorterTests/ImageTests/ImageTestHelpers.cs
+++ b/PixelsorterTests/ImageTests/ImageTestHelpers.cs
@@ -10,20 +10,20 @@ namespace Pixelsorter.Tests.ImageTests
         public static readonly String[] FileExtensions = [".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp"];
         public static readonly int[] ChannelCounts = [1, 3, 4];
 
-        public static string CreateTestImage(String ext, int chanels)
+        public static string CreateTestImage(String ext, int chanels, int width = 24, int height = 24)
         {
             String path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"test_image_{Guid.NewGuid()}{ext}");
             switch (chanels)
             {
                 case 1:
-                    using (var image = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.L8>(24, 24)) image.Save(path);
+                    using (var image = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.L8>(width, height)) image.Save(path);
                     break;
                 case 3:
-                    using (var image = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgb24>(24, 24)) image.Save(path);
+                    using (var image = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgb24>(width, height)) image.Save(path);
                     break;
                 case 4:
                 default:
-                    using (var image = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>(24, 24)) image.Save(path);
+                    using (var image = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>(width, height)) image.Save(path);
                     break;
             }
             return path;

--- a/PixelsorterTests/ImageTests/LoadImageTests.cs
+++ b/PixelsorterTests/ImageTests/LoadImageTests.cs
@@ -11,7 +11,7 @@ namespace Pixelsorter.Tests.ImageTests
             string path = ImageTestHelpers.CreateTestImage(extension, channels);
             try
             {
-                var image = Image.LoadImage(path);
+                var (image, _) = Image.LoadImage(path);
 
                 Assert.NotNull(image);
             }
@@ -64,7 +64,7 @@ namespace Pixelsorter.Tests.ImageTests
             string path = ImageTestHelpers.CreateTestImageWithAlpha(extension);
             try
             {
-                var image = Image.LoadImage(path);
+                var (image, _) = Image.LoadImage(path);
                 Assert.NotNull(image);
             }
             finally
@@ -80,7 +80,7 @@ namespace Pixelsorter.Tests.ImageTests
             string path = ImageTestHelpers.CreateGrayscaleTestImage(extension);
             try
             {
-                var image = Image.LoadImage(path);
+                var (image, _) = Image.LoadImage(path);
                 Assert.NotNull(image);
             }
             finally

--- a/PixelsorterTests/ImageTests/SaveImageTests.cs
+++ b/PixelsorterTests/ImageTests/SaveImageTests.cs
@@ -17,7 +17,7 @@ namespace Pixelsorter.Tests.ImageTests
             string outPath = Path.Combine(Path.GetTempPath(), $"test_save_image_{Guid.NewGuid()}{extension}");
             try
             {
-                var image = Image.LoadImage(inPath);
+                var (image, _) = Image.LoadImage(inPath);
                 Image.SaveImage(image, outPath);
 
                 Assert.True(File.Exists(outPath));
@@ -61,7 +61,7 @@ namespace Pixelsorter.Tests.ImageTests
             string outPath = Path.Combine(Path.GetTempPath(), $"test_save_image_alpha_{Guid.NewGuid()}{extension}");
             try
             {
-                var image = Image.LoadImage(inPath);
+                var (image, _) = Image.LoadImage(inPath);
                 Image.SaveImage(image, outPath);
 
                 Assert.True(File.Exists(outPath));
@@ -82,7 +82,7 @@ namespace Pixelsorter.Tests.ImageTests
             string outPath = Path.Combine(Path.GetTempPath(), $"test_save_image_grayscale_{Guid.NewGuid()}{extension}");
             try
             {
-                var image = Image.LoadImage(inPath);
+                var (image, _) = Image.LoadImage(inPath);
                 Image.SaveImage(image, outPath);
 
                 Assert.True(File.Exists(outPath));

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ string inputPath = "input.jpg";
 string outputPath = "output.jpg";
 
 // 1. Load the image into an NDArray
-NDArray imageData = Image.LoadImage(inputPath);
+NDArray (imageData, _) = Image.LoadImage(inputPath);
+
+// Or load image donwnscaled for faster processing
+// (imageData, originalSize) = Image.LoadImage(inputImagePath, KnownResamplers.NearestNeighbor);
 
 // 2. Get mask options
 
@@ -40,6 +43,9 @@ NDArray sortedData = Sorter.SortImage(imageData, SortBy.Warmth(), SortDirections
 
 // 5. Save the sorted image to disk
 Image.SaveImage(sortedData, outputPath);
+
+// Upscale again to original size if the image was loaded downscaled
+// Image.SaveImage(sortedData, outputPath, KnownResamplers.NearestNeighbor, originalSize);
 ```
 
 ## Available Sorting Criteria


### PR DESCRIPTION
## Description
Images can now be downscaled to 1080p before sorting and optionaly upscaled again after sorting. This can make the sorting faster by a factor of ca. 4x for 4k images.

Fixes # (issue)
https://github.com/h43lb1t0/PixelsorterApp/issues/35

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested with Unit Tests (Required)
- [x] Tested with ConsoleApp output
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new dependencies, they use MIT/Apache 2.0 licenses or their compatibility is explicitly mentioned in the description
